### PR TITLE
Update noxfile

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import nox
 
-LINT_FILES = " ".join(glob.glob("*.py"))
+LINT_FILES = [" ".join(glob.glob("*.py"))]
 
 requirements_directory = Path("requirements")
 
@@ -86,3 +86,10 @@ def typing(session: nox.Session):
     """
     install(session, req="typing")
     session.run("mypy", *session.posargs, *LINT_FILES)
+
+
+@nox.session
+def lint(session: nox.Session):
+    session.notify("static")
+    session.notify("formatters")
+    session.notify("typing")

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,8 +1,9 @@
+import glob
 from pathlib import Path
 
 import nox
 
-LINT_FILES = ["forge-webhook-parser.py"]
+LINT_FILES = " ".join(glob.glob("*.py"))
 
 requirements_directory = Path("requirements")
 

--- a/requirements/typing.in
+++ b/requirements/typing.in
@@ -1,1 +1,2 @@
 mypy
+nox

--- a/requirements/typing.txt
+++ b/requirements/typing.txt
@@ -4,9 +4,25 @@
 #
 #    pip-compile --allow-unsafe --output-file=requirements/typing.txt --strip-extras requirements/typing.in
 #
+argcomplete==3.5.0
+    # via nox
+colorlog==6.8.2
+    # via nox
+distlib==0.3.8
+    # via virtualenv
+filelock==3.16.1
+    # via virtualenv
 mypy==1.11.2
     # via -r requirements/typing.in
 mypy-extensions==1.0.0
     # via mypy
+nox==2024.4.15
+    # via -r requirements/typing.in
+packaging==24.1
+    # via nox
+platformdirs==4.3.6
+    # via virtualenv
 typing-extensions==4.12.2
     # via mypy
+virtualenv==20.26.5
+    # via nox


### PR DESCRIPTION
This PR adds some changes to improve the noxfile:

- Create a space separated list of all Python files, instead of just the parser. Right now there is only the noxfile.py and the parser but we might add more.
- Create a "lint" session that runs several checks with a single command. I forgot that if I do just "nox" then it runs the pip-compile sessions, which I don't want to do when just checking / formatting code.
- Adds nox to the typing dependencies. Otherwise mypy throws an "import-not-found" error.