### PR TITLE
do not join lint filenames

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import nox
 
-LINT_FILES = [" ".join(glob.glob("*.py"))]
+LINT_FILES = glob.glob("*.py")
 
 requirements_directory = Path("requirements")
 


### PR DESCRIPTION
This fixes an issue in ci where the Python files were joined into a single string and the space was treated as a file name, which caused failures. Instead we should provide filenames individually.